### PR TITLE
Turn on coolant early

### DIFF
--- a/syil_syntec.cps
+++ b/syil_syntec.cps
@@ -1378,6 +1378,9 @@ function onSection() {
     }
   }
 
+  // set coolant after tool change, before positiong wcs
+  setCoolant(tool.coolant);
+
   // wcs
   if (insertToolCall || operationNeedsSafeStart) { // force work offset when changing tool
     currentWorkOffset = undefined;
@@ -1500,8 +1503,6 @@ function onSection() {
       yOutput.format(initialPosition.y)
     );
   }
-  // set coolant after we have positioned at Z
-  setCoolant(tool.coolant);
 
   validate(lengthCompensationActive, "Length compensation is not active.");
 


### PR DESCRIPTION
Currently, coolant is turned on after tool change & positioning the axis. Because the coolant system may take a second to prime, there's a risk of the initial cut being made without coolant.

This change moves the code to turn on coolant early: right after tool change, and before axis positioning.

Before:
```
N30 T1 M06
N35 T2
N40 S5000 M03
N45 G54
N50 G00 X80. Y-24.375
N55 G43 Z15. H01
N60 M08
N65 G00 Z5.
N70 G01 Z-1. F1000.
```

After:
```
N30 T1 M06
N35 T2
N40 S5000 M03
N45 M08
N50 G54
N55 G00 X80. Y-24.375
N60 G43 Z15. H01
N70 G01 Z-1. F1000.
```