### PR TITLE
Support customize table position at end of program

### DIFF
--- a/syil_syntec.cps
+++ b/syil_syntec.cps
@@ -210,6 +210,22 @@ properties = {
     ],
     value: "G28",
     scope: "post"
+  },
+  endOfProgramTableX: {
+    title      : "Table X position at end of program",
+    description: "Determines the X axis table position at the end of the program",
+    group      : "preferences",
+    type       : "number",
+    value      : -7.5,
+    scope      : "post"
+  },
+  endOfProgramTableY: {
+    title      : "Table Y position at end of program",
+    description: "Determines the Y axis table position at the end of the program",
+    group      : "preferences",
+    type       : "number",
+    value      : 0.0,
+    scope      : "post"
   }
 };
 
@@ -2811,7 +2827,11 @@ function onClose() {
   zOutput.reset();
 
   // G53 G0 G90 X-7.5 Y0.
-  writeBlock(gFormat.format(53), gAbsIncModal.format(90), gMotionModal.format(0), xOutput.format(-7.5), yOutput.format(0));
+  writeBlock(gFormat.format(53),
+             gAbsIncModal.format(90),
+             gMotionModal.format(0),
+             xOutput.format(getProperty("endOfProgramTableX")),
+             yOutput.format(getProperty("endOfProgramTableY")));
 
   // forceWorkPlane();
   // setWorkPlane(new Vector(0, 0, 0)); // reset working plane

--- a/syil_syntec.cps
+++ b/syil_syntec.cps
@@ -2800,6 +2800,7 @@ function onClose() {
   optionalSection = false;
 
   onCommand(COMMAND_COOLANT_OFF);
+  onCommand(COMMAND_STOP_SPINDLE);
 
   disableLengthCompensation(true);
   cancelWorkPlane();
@@ -2809,9 +2810,12 @@ function onClose() {
 
   zOutput.reset();
 
-  forceWorkPlane();
-  setWorkPlane(new Vector(0, 0, 0)); // reset working plane
-  writeRetract(X, Y); // return to home
+  // G53 G0 G90 X-7.5 Y0.
+  writeBlock(gFormat.format(53), gAbsIncModal.format(90), gMotionModal.format(0), xOutput.format(-7.5), yOutput.format(0));
+
+  // forceWorkPlane();
+  // setWorkPlane(new Vector(0, 0, 0)); // reset working plane
+  // writeRetract(X, Y); // return to home
 
   onImpliedCommand(COMMAND_END);
   onImpliedCommand(COMMAND_STOP_SPINDLE);


### PR DESCRIPTION
- Support customization of table position at end of program
- Available as post properties, `endOfProgramTableX`, and `endOfProgramTableY`, default to X-7.5 Y0, so that table is centered
- Set `endOfProgramTableX = 0`, `endOfProgramTableY = 0` to revert to factory post behavior (table positioned at X0 Y0)

Also included in the change:
- Stop spindle sooner at the end of program
- Factory post stops the spindle after the table/spindle returns to home position
- This change stops it before returning to home position, as time as turning off coolant