### PR TITLE
Fix issue with probe not turning off if it's the last operation

### DIFF
--- a/syil_syntec.cps
+++ b/syil_syntec.cps
@@ -6,8 +6,8 @@
   Modified by Derek Li.
   https://github.com/derek1ee/fusion-syil-22ma
 
-  $Revision: 44015 $
-  $Date: 2023-03-17 21:50:00 $
+  $Revision: 44016 $
+  $Date: 2023-04-04 22:20:00 $
 */
 
 description = "Unofficial Post for Syil w/ Syntec Controller";
@@ -2744,6 +2744,11 @@ function onSectionEnd() {
     if(hasNextSection() && (getNextSection().getTool().number != currentSection.getTool().number)) {
       // Do not turn off probe if there are additional probing operation,
       // Turning probe on/off quickly seems to hang the controller on next M80.
+      writeBlock(mFormat.format(81)); // M81 turns off probe
+    }
+
+    if(!hasNextSection()) {
+      // Turn off probe if it's the last operation
       writeBlock(mFormat.format(81)); // M81 turns off probe
     }
   }


### PR DESCRIPTION
When probing is only needed once to set the WCS instead of every time a new part is loaded, it's a good idea to keep the probing operations at the bottom of the CAM setup, after a manual NC that will end the program. This way, when needed to probe, the operator can jump after the manual NC to run the probing ops. The benefit is that probing is kept together with the main program instead of a separate program, and the whole thing only needs to be post processed once as a whole.

The bug is a result of an earlier change, when probing is the last operation, no M81 will be generated, and the probe will be left on. The fix is to check to see when there's no next section, write M81.