### PR TITLE
Support in-process tool measure and break control

### DIFF
--- a/syil_syntec.cps
+++ b/syil_syntec.cps
@@ -2757,6 +2757,7 @@ function onCommand(command) {
   case COMMAND_PROBE_ON:
     // writeBlock(gFormat.format(65), "P" + 9832); // Turn on probe
     writeBlock(mFormat.format(80)); // M80 turns on probe
+    writeBlock(mFormat.format(19)); // Spindle lock
     return;
   case COMMAND_PROBE_OFF:
     // writeBlock(gFormat.format(65), "P" + 9833); // Turn off probe
@@ -2784,7 +2785,7 @@ function onSectionEnd() {
         onCommand(COMMAND_COOLANT_OFF);
         onCommand(COMMAND_STOP_SPINDLE);
 
-        if (tool.getBreakControl() || getProperty("breakControl")) {
+        if (tool.getBreakControl() || (!isProbeOperation() && getProperty("breakControl"))) {
           onCommand(COMMAND_BREAK_CONTROL);
         }
   }


### PR DESCRIPTION
Add support for in-process tool measurement and break control, two flavors of macros are supported, `pioneer` (default option) which is supplied by Syil, and `renishaw-primo` which is supplied by Renishaw with Primo LTS.

### Tool measurement
Too measurement is invoked by using `Manual NC`, and selecting 'Tool measure`. It will measure the tool in operation immediately following the Manual NC operation.

<img width="189" alt="image" src="https://github.com/derek1ee/fusion-syil-22ma/assets/6037220/65fc4692-b83a-47a5-8cb9-eac888b45528">

<img width="211" alt="image" src="https://github.com/derek1ee/fusion-syil-22ma/assets/6037220/fbd7806b-ef4e-43b2-874d-6ccd664188a5">
(Will measure `T46`)

### Break control
Break control is triggered either by marking the tool with `Break control` flag in the Fusion tool library, via `Manual NC` command and selecting `Tool break control`, or turn on globally via the `Break control` setting in post processor. **Note that Pioneer macros supplied by Syil doesn't not include break control macrol** 

Break control will skip if the tool is a probe, even if it's turned on globally via the post processor parameter.

<img width="211" alt="image" src="https://github.com/derek1ee/fusion-syil-22ma/assets/6037220/72c8bac1-07fd-4834-be34-c8ee556b364f">
(Will perform break control for T50)

### Also changed

- Support M7 to turn on air blast.
- Lock spindle at the beginning of probing op.